### PR TITLE
Add configurable jni methods visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This will require some investigation and testing.*
 ```kotlin
 plugins {
     //...
-    id("io.github.andrefigas.rustjni") version "0.0.21"
+    id("io.github.andrefigas.rustjni") version "0.0.22"
 }
 ```
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
     google()
 }
 
-version = "0.0.21"
+version = "0.0.22"
 group = "io.github.andrefigas.rustjni"
 
 gradlePlugin {

--- a/gradle-plugin/src/main/kotlin/io/github/andrefigas/rustjni/RustJniExtension.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/andrefigas/rustjni/RustJniExtension.kt
@@ -4,6 +4,7 @@ import io.github.andrefigas.rustjni.AndroidTarget.AARCH64_LINUX_ANDROID
 import io.github.andrefigas.rustjni.AndroidTarget.ARMV7_LINUX_ANDROIDEABI
 import io.github.andrefigas.rustjni.AndroidTarget.I686_LINUX_ANDROID
 import io.github.andrefigas.rustjni.AndroidTarget.X86_64_LINUX_ANDROID
+import io.github.andrefigas.rustjni.reflection.Visibility
 
 open class RustJniExtension {
 
@@ -39,6 +40,13 @@ open class RustJniExtension {
      *
      * This is used to generated Rust code and library loader in the named Class. */
     var jniHost = DEFAULT_JNI_HOST
+
+    /** The visibility of the generated functions in the Class [jniHost].
+     * Default is [Visibility.DEFAULT].
+     * Options are [Visibility.PUBLIC], [Visibility.PROTECTED], [Visibility.PRIVATE], [Visibility.DEFAULT].
+     * Disclaimer: DEFAULT will omit the visibility modifier and assume the default visibility of the Programming Language.
+     */
+    var jniMethodsVisibility : Visibility = Visibility.DEFAULT
 
     /** Whether `native`/`extern` functions should be generated in the Class [jniHost].
      *

--- a/gradle-plugin/src/main/kotlin/io/github/andrefigas/rustjni/reflection/ReflectionJVM.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/andrefigas/rustjni/reflection/ReflectionJVM.kt
@@ -101,7 +101,7 @@ internal object ReflectionJVM {
             throw org.gradle.api.GradleException("No JNI methods found for class $jniHost in lib.rs")
         }
 
-        return buildMethodDeclarations(methodsToGenerate, FileUtils.getLibName(project, extension), isKotlinFile)
+        return buildMethodDeclarations(extension, methodsToGenerate, FileUtils.getLibName(project, extension), isKotlinFile)
     }
 
     private fun parseRustJniFunctions(
@@ -187,19 +187,20 @@ internal object ReflectionJVM {
 
     // Generates method declarations for Kotlin or Java files
     private fun buildMethodDeclarations(
+        extension: RustJniExtension,
         methodsToGenerate: List<MethodSignature>,
         libName: String,
         isKotlinFile: Boolean
     ): String {
         val methodDeclarations = methodsToGenerate.joinToString("\n\n") { method ->
             if (isKotlinFile) {
-                "private external fun ${method.methodName.substringAfterLast('_')}(${method.parameters.joinToString(", ")}): ${method.returnType}"
+                "${extension.jniMethodsVisibility} external fun ${method.methodName.substringAfterLast('_')}(${method.parameters.joinToString(", ")}): ${method.returnType}"
             } else {
                 val paramsJava = method.parameters.joinToString(", ") { param ->
                     val parts = param.split(":")
                     "${parts[1].trim()} ${parts[0].trim()}"
                 }
-                "private static native ${method.returnType} ${method.methodName.substringAfterLast('_')}($paramsJava);"
+                "${extension.jniMethodsVisibility} static native ${method.returnType} ${method.methodName.substringAfterLast('_')}($paramsJava);"
             }
         }
 

--- a/gradle-plugin/src/main/kotlin/io/github/andrefigas/rustjni/reflection/Visibility.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/andrefigas/rustjni/reflection/Visibility.kt
@@ -1,0 +1,17 @@
+package io.github.andrefigas.rustjni.reflection
+
+/**
+ * Enum class that represents the visibility of a methods
+ * Since internal visibility is only available in Kotlin, it is not supported here
+ */
+enum class Visibility(private val label : String) {
+    PUBLIC("public"),
+    PROTECTED("protected"),
+    PRIVATE("private"),
+    // Default omits the visibility modifier and assume the default visibility of the Programming Language:
+    // Java: package-private, Kotlin: public
+    DEFAULT("");
+
+    override fun toString() = label
+    
+}


### PR DESCRIPTION
#19 

- [Add configurable jni methods visibility](https://github.com/andrefigas/RustJNI/commit/ca1a6b2016974f7e96d6b350df15e8b393f530d9)