### PR TITLE
Support rust version constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,27 @@ rustJni{
 }
 ```
 
+### How to define what Rust version is acceptable to compile your project ?
+
+You can define the Rust version that is acceptable to compile your project.
+This is useful if you want to ensure that your project is always compiled with a specific version of Rust.
+
+```kotlin
+rustJni{
+    //...
+    rustVersion = "1.86.0"
+    //...
+}
+```
+
+#### Supported `rustVersion` patterns
+
+| Feature           | Pattern Example               | Description                                         |
+|------------------|-------------------------------|-----------------------------------------------------|
+| Exact version     | `1.86.0`                      | Only this exact Rust version is accepted           |
+| Minimum version   | `>=1.64.0`                    | Accepts any version greater than or equal to this  |
+| Wildcard version  | `1.86.*`, `1.*.*`             | Allows flexibility within minor and/or patch versions |
+
 ### How can I take a look at some samples?
 
 - [Java](./sample/java) - A java sample with 1 method

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
     google()
 }
 
-version = "0.0.23"
+version = "0.0.24"
 group = "io.github.andrefigas.rustjni"
 
 gradlePlugin {

--- a/gradle-plugin/src/main/kotlin/io/github/andrefigas/rustjni/RustJniExtension.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/andrefigas/rustjni/RustJniExtension.kt
@@ -53,6 +53,26 @@ open class RustJniExtension {
      * Default is `true`. */
     var exportFunctions = true
     var applyAsCompileDependency = true
+
+    /**
+     * Specifies the required Rust version for this project.
+     *
+     * This field accepts the following formats:
+     *
+     * 1. Exact version:
+     *    - Example: "1.76.0"
+     *    - The build will require exactly this Rust version.
+     *
+     * 2. Minimum version (range):
+     *    - Example: ">=1.64.0"
+     *    - Indicates that the project requires at least version 1.64.0 of Rust or newer.
+     *
+     * 3. Wildcard version:
+     *    - Example: "1.76.*"
+     *    - Allows any patch version within the specified minor version (e.g., 1.76.0, 1.76.1, etc).
+     */
+    var rustVersion: String = ""
+
     private var architectures: (ArchitectureListScope.() -> Unit)? = null
 
     fun architectures(architectures: ArchitectureListScope.() -> Unit) {

--- a/sample/java/app/build.gradle.kts
+++ b/sample/java/app/build.gradle.kts
@@ -3,7 +3,7 @@ import io.github.andrefigas.rustjni.reflection.Visibility
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
-    id("io.github.andrefigas.rustjni") version "0.0.23"
+    id("io.github.andrefigas.rustjni") version "0.0.24"
 }
 
 rustJni{
@@ -17,6 +17,7 @@ rustJni{
         i686_linux_android("i686-linux-android21-clang")
         x86_64_linux_android("x86_64-linux-android21-clang")
     }
+    rustVersion = ">=1.0.0"
 }
 
 android {

--- a/sample/kotlin/app/build.gradle.kts
+++ b/sample/kotlin/app/build.gradle.kts
@@ -3,7 +3,7 @@ import io.github.andrefigas.rustjni.reflection.Visibility
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
-    id("io.github.andrefigas.rustjni") version "0.0.23"
+    id("io.github.andrefigas.rustjni") version "0.0.24"
 }
 
 rustJni{
@@ -17,6 +17,7 @@ rustJni{
         i686_linux_android("i686-linux-android21-clang")
         x86_64_linux_android("x86_64-linux-android21-clang")
     }
+    rustVersion = ">=1.0.0"
 }
 
 android {


### PR DESCRIPTION
This PR implements support for validating the Rust toolchain version used in the local environment, based on a version constraint defined by the user in the Gradle configuration.

Projects can now declare which Rust version is considered compatible using the rustVersion property inside the rustJni extension block. Supported formats include:

Exact version: "1.86.0"

Minimum version: ">=1.64.0"

Wildcard versions: "1.86.*", "1.*.*"

If the installed Rust version does not match the constraint, the build will fail with a clear and actionable error message.

This validation runs after the project is evaluated, ensuring that any value provided by the user is respected before checking.

📌 Solves: [#28](https://github.com/andrefigas/RustJNI/issues/28)

🛠️ Implementation Note
Previously, the plugin accessed values from the rustJni extension immediately during apply(project), which caused it to read default values before the user-defined configuration in build.gradle.kts was applied.

This PR moves all logic that depends on user-defined values (such as version validation) into an afterEvaluate block. This ensures that the plugin uses the final, user-configured values from the build script, avoiding incorrect or premature validation.