### PR TITLE
Make the generated code compliant with cargo fmt

### DIFF
--- a/gradle-plugin/src/main/kotlin/io/github/andrefigas/rustjni/RustJNI.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/andrefigas/rustjni/RustJNI.kt
@@ -385,7 +385,7 @@ class RustJNI : Plugin<Project> {
                 use jni::objects::JClass;
                 //<RustJNI>
                 // primitive imports
-                use jni::sys::{jstring};
+                use jni::sys::jstring;
                 //</RustJNI>
     
                 #[no_mangle]

--- a/gradle-plugin/src/main/kotlin/io/github/andrefigas/rustjni/reflection/ReflectionNative.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/andrefigas/rustjni/reflection/ReflectionNative.kt
@@ -261,7 +261,7 @@ internal object ReflectionNative {
             println("No imports were removed.")
         }
 
-        rustFile.writeText(filteredLines.joinToString("\n"))
+        rustFile.writeText(filteredLines.joinToString("\n") + "\n")
     }
 
     // Adds primitive imports to the Rust file if needed
@@ -279,7 +279,11 @@ internal object ReflectionNative {
         }
 
         if (primitiveTypes.isNotEmpty()) {
-            val importsLine = "use jni::sys::{${primitiveTypes.joinToString(", ")}};"
+            val importsLine = if (primitiveTypes.size == 1) {
+                "use jni::sys::${primitiveTypes.first()};"
+            } else {
+                "use jni::sys::{${primitiveTypes.joinToString(", ")}};"
+            }
             val updatedLines = lines.toMutableList()
             var inserted = false
 
@@ -299,7 +303,7 @@ internal object ReflectionNative {
             }
 
             println("Added Imports: $importsLine")
-            rustFile.writeText(updatedLines.joinToString("\n"))
+            rustFile.writeText(updatedLines.joinToString("\n") + "\n")
         }
     }
 

--- a/sample/java/app/src/main/rust/src/lib.rs
+++ b/sample/java/app/src/main/rust/src/lib.rs
@@ -1,8 +1,8 @@
-use jni::JNIEnv;
 use jni::objects::JClass;
+use jni::JNIEnv;
 //<RustJNI>
 // primitive imports
-use jni::sys::{jstring};
+use jni::sys::jstring;
 //</RustJNI>
 
 #[no_mangle]

--- a/sample/kotlin/app/src/main/rust/src/lib.rs
+++ b/sample/kotlin/app/src/main/rust/src/lib.rs
@@ -1,19 +1,18 @@
-use jni::JNIEnv;
 use jni::objects::JClass;
+use jni::JNIEnv;
 //<RustJNI>
 // primitive imports
-use jni::sys::{jstring};
-//</RustJNI>        
+use jni::sys::jstring;
+//</RustJNI>
 #[no_mangle]
 pub extern "C" fn Java_com_devfigas_rustjni_sample_MainActivity_sayHello(
     env: JNIEnv,
     _class: JClass,
-    
 ) -> jstring {
     println!("Parameters: {:?}", ());
 
     let output = r#"Rust Method: sayHello"#;
-env.new_string(output)
-    .expect("Couldn't create Java string!")
-    .into_raw()
+    env.new_string(output)
+        .expect("Couldn't create Java string!")
+        .into_raw()
 }


### PR DESCRIPTION
This PR only adds some minor changes to match cargo fmt requirements. 
Here are the two changes:
- Remove brackets when making a single import.
- Add an empty line at the end of the file.

This changes have been tested locally and passes the tests.
I've also changed the sample files. 