### PR TITLE
Receive cargo home as a parameter via local.properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,17 @@ rustJni{
 | Minimum version   | `>=1.64.0`                    | Accepts any version greater than or equal to this  |
 | Wildcard version  | `1.86.*`, `1.*.*`             | Allows flexibility within minor and/or patch versions |
 
+### How to define a custom path for rust?
+
+By default, Rust is installed in the following directory:
+
+- **macOS/Linux**: `~/.cargo/bin`
+- **Windows**: `%USERPROFILE%\.cargo\bin`
+
+However, you can specify a custom installation directory by setting it in your **`local.properties`** file. For example:
+
+`cargo.dir=/Users/<user>/cargo_tmp/.cargo/bin`
+
 ### How can I take a look at some samples?
 
 - [Java](./sample/java) - A java sample with 1 method

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
     google()
 }
 
-version = "0.0.25"
+version = "0.0.26"
 group = "io.github.andrefigas.rustjni"
 
 gradlePlugin {

--- a/sample/java/app/build.gradle.kts
+++ b/sample/java/app/build.gradle.kts
@@ -3,7 +3,7 @@ import io.github.andrefigas.rustjni.reflection.Visibility
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
-    id("io.github.andrefigas.rustjni") version "0.0.25"
+    id("io.github.andrefigas.rustjni") version "0.0.26"
 }
 
 rustJni{

--- a/sample/kotlin/app/build.gradle.kts
+++ b/sample/kotlin/app/build.gradle.kts
@@ -3,7 +3,7 @@ import io.github.andrefigas.rustjni.reflection.Visibility
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
-    id("io.github.andrefigas.rustjni") version "0.0.25"
+    id("io.github.andrefigas.rustjni") version "0.0.26"
 }
 
 rustJni{


### PR DESCRIPTION
- Added support for using a custom Rust installation directory, as long as it is defined in `local.properties` using the `cargo.dir` property.
- Moved Rust version validation from the configuration phase to the Rust code compilation phase.

This will close issue #32.