### PR TITLE
Fix the support for Cargo checking on Windows

### DIFF
--- a/gradle-plugin/src/main/kotlin/io/github/andrefigas/rustjni/RustJNI.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/andrefigas/rustjni/RustJNI.kt
@@ -228,7 +228,9 @@ class RustJNI : Plugin<Project> {
                 throw GradleException("Cargo directory does not exist: $cargoDir")
             }
 
-            val executables = listOf("cargo", "rustc", "rustup")
+            val isWindows = System.getProperty("os.name").lowercase().contains("win")
+            val execExt = if (isWindows) ".exe" else ""
+            val executables = listOf("cargo$execExt", "rustc$execExt", "rustup$execExt")
             for (exe in executables) {
                 validateRustExecutable(File(cargoDirFile, exe))
             }


### PR DESCRIPTION
When support was added for installations in non-default folders, a check was introduced to verify whether the Cargo executable actually exists before proceeding.

However, the .exe extension required on Windows was not taken into account during this validation. As a result, the check would fail on Windows systems even if the executable was correctly installed.

This PR fixes that issue by ensuring the check properly includes the .exe extension on Windows platforms.

Closes #32