### PR TITLE
Add CD workflow for Gradle Plugin Portal

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,44 @@
+name: CD - Publish to Gradle Plugin Portal
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: release
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'zulu'
+        java-version: '17'
+
+    - name: Cache Gradle dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+
+    - name: Grant execute permission for Gradle Wrapper
+      run: chmod +x gradle-plugin/gradlew
+
+    - name: Build plugin
+      run: |
+        cd gradle-plugin
+        ./gradlew build
+
+    - name: Publish to Gradle Plugin Portal
+      run: |
+        cd gradle-plugin
+        ./gradlew publishPlugins -Pgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }} -Pgradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }}


### PR DESCRIPTION
## Summary
- Adds a CD workflow that publishes the plugin to Gradle Plugin Portal on push to `main`
- Uses GitHub Environment `release` with required reviewer for secure access control over publish credentials

## Manual setup required
1. Go to **Settings > Environments > New environment** > name it `release`
2. **Protection rules**: Required reviewers > add `andrefigas`
3. **Deployment branches**: Selected branches > `main`
4. **Environment secrets**: add `GRADLE_PUBLISH_KEY` and `GRADLE_PUBLISH_SECRET`

## Test plan
- [ ] Complete manual setup above
- [ ] Merge a PR to main and verify the workflow triggers
- [ ] Approve the deployment and verify plugin appears on https://plugins.gradle.org/plugin/io.github.andrefigas.rustjni